### PR TITLE
Use correct paths for PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Concardis\\Payengine\\Lib\\": "src/"
+      "Concardis\\Payengine\\Lib\\": "src/Concardis/Payengine/Lib"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Concardis\\Payengine\\Lib\\Test\\": "tests/"
+      "Concardis\\Payengine\\Lib\\Test\\": "tests/Concardis/Payengine/Lib/Test"
     }
   }
-
 }


### PR DESCRIPTION
When using the library with composer the classes cannot be found because of the incorrect paths in `composer.json`. This PR changes them to match the ones defined in https://github.com/concardis/PHP_SDK/blob/71dd9b20cd8f0709272bfb86ad5bf17ec505524f/autoload.php#L6-L7