### PR TITLE
Support retrieving the provider code of a transaction

### DIFF
--- a/src/Concardis/Payengine/Lib/Models/Response/Orders/Transaction.php
+++ b/src/Concardis/Payengine/Lib/Models/Response/Orders/Transaction.php
@@ -82,6 +82,11 @@ class Transaction extends AbstractResponseModel
     private $initialAmount;
 
     /**
+     * @var string
+     */
+    private $providerCode;
+
+    /**
      * @return string
      */
     public function getType()
@@ -289,5 +294,20 @@ class Transaction extends AbstractResponseModel
         $this->initialAmount = $initialAmount;
     }
 
+    /**
+     * @return string
+     */
+    public function getProviderCode()
+    {
+        return $this->providerCode;
+    }
+
+    /**
+     * @param string $providerCode
+     */
+    public function setProviderCode($providerCode)
+    {
+        $this->providerCode = $providerCode;
+    }
 
 }

--- a/tests/Concardis/Payengine/Lib/Test/Fixture/Model/TransactionFixture.php
+++ b/tests/Concardis/Payengine/Lib/Test/Fixture/Model/TransactionFixture.php
@@ -34,6 +34,7 @@ class TransactionFixture
         $transaction->setCurrency("EUR");
         $transaction->setCapturedAmount(12345);
         $transaction->setCanceledAmount(12345);
+        $transaction->setProviderCode("00");
         return $transaction;
 
     }
@@ -56,6 +57,7 @@ class TransactionFixture
         $transaction->setCurrency("EUR");
         $transaction->setCapturedAmount(12345);
         $transaction->setCanceledAmount(12345);
+        $transaction->setProviderCode("00");
         return $transaction;
     }
 

--- a/tests/Concardis/Payengine/Lib/Test/Models/Response/OrderTest.php
+++ b/tests/Concardis/Payengine/Lib/Test/Models/Response/OrderTest.php
@@ -145,6 +145,7 @@ class OrderTest extends TestCase
             $this->assertArrayHasKey('refundedAmount', $transaction);
             $this->assertArrayHasKey('capturedAmount', $transaction);
             $this->assertArrayHasKey('initialAmount', $transaction);
+            $this->assertArrayHasKey('providerCode', $transaction);
         }
     }
 

--- a/tests/Concardis/Payengine/Lib/Test/Models/Response/Orders/TransactionTest.php
+++ b/tests/Concardis/Payengine/Lib/Test/Models/Response/Orders/TransactionTest.php
@@ -39,6 +39,7 @@ class TransactionTest extends TestCase
         $this->assertArrayHasKey('refundedAmount', $modelToArray);
         $this->assertArrayHasKey('capturedAmount', $modelToArray);
         $this->assertArrayHasKey('initialAmount', $modelToArray);
+        $this->assertArrayHasKey('providerCode', $modelToArray);
 
     }
 
@@ -62,6 +63,7 @@ class TransactionTest extends TestCase
         $this->assertArrayHasKey('refundedAmount', $responseFromMiddleware);
         $this->assertArrayHasKey('capturedAmount', $responseFromMiddleware);
         $this->assertArrayHasKey('initialAmount', $responseFromMiddleware);
+        $this->assertArrayHasKey('providerCode', $responseFromMiddleware);
         $this->assertInternalType('array', $responseFromMiddleware['order']);
 
         $transactionFromResponse = new Transaction();
@@ -92,6 +94,7 @@ class TransactionTest extends TestCase
         $this->assertArrayHasKey('refundedAmount', $responseFromMiddleware);
         $this->assertArrayHasKey('capturedAmount', $responseFromMiddleware);
         $this->assertArrayHasKey('initialAmount', $responseFromMiddleware);
+        $this->assertArrayHasKey('providerCode', $responseFromMiddleware);
         $this->assertInternalType('array', $responseFromMiddleware['order']);
 
         $transactionFromResponse = new Transaction();


### PR DESCRIPTION
This change adds a getter and setter method to the Transaction response model to get the provider code as mentioned on https://docs.payengine.de/integration-types/build-your-own/api/providercodes/.