### PR TITLE
Pass an empty array to Curl::get() to fix warning on counting non countable

### DIFF
--- a/src/Concardis/Payengine/Lib/Internal/AbstractClass/AbstractResource.php
+++ b/src/Concardis/Payengine/Lib/Internal/AbstractClass/AbstractResource.php
@@ -103,8 +103,10 @@ abstract class AbstractResource
         if($this->resourceId == null) {
             if(is_array($filter)){
                 TypeHelper::convertBooleanValues($filter);
+                $result = $this->getAll($filter);
+            } else {
+                $result = $this->getAll();
             }
-            $result = $this->getAll($filter);
         } else {
             $result = $this->getOne();
         }
@@ -117,7 +119,7 @@ abstract class AbstractResource
      * @return ListWrapper
      * @throws \Exception
      */
-    private function getAll($filter = null){
+    private function getAll($filter = array()){
         $result = $this->connection->get($this->resourcePath, $filter);
         $listWrapper = new ListWrapper();
 
@@ -137,7 +139,7 @@ abstract class AbstractResource
      * @return AbstractResponseModel
      */
     private function getOne() {
-        $result = $this->connection->get($this->resourcePathWithId, null);
+        $result = $this->connection->get($this->resourcePathWithId);
         return $this->responseDataToModel($result);
     }
 

--- a/src/Concardis/Payengine/Lib/Internal/Connection/Connection.php
+++ b/src/Concardis/Payengine/Lib/Internal/Connection/Connection.php
@@ -166,7 +166,7 @@ class Connection implements ConnectionInterface
         $url = preg_replace('/(%5B[0-9]%5D)/', '', $url);
 
         $this->setDefaultHeader();
-        $this->curl->get($url, null);
+        $this->curl->get($url, array());
         if(!$this->curl->isSuccess()){
             $requestException = new PayengineResourceException(
                 $this->curl->error_message, $this->curl->http_status_code


### PR DESCRIPTION
Fixes #12.